### PR TITLE
README: Bump the Leiningen version to 0.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple CAS client for Clojure, for use as a middleware with Ring.
 To install, add this to your project.clj:
 
 ```clojure
-  :dependencies [[clj-cas-client "0.0.5"]]
+  :dependencies [[clj-cas-client "0.0.6"]]
 ```
 
 To wrap a handler with cas:


### PR DESCRIPTION
Had some trouble using the middleware until I noticed there was actually a higher version available, and already referenced in the code. Worked like a charm after the version bump, though. Thanks so much for this.
